### PR TITLE
improve building for local testing

### DIFF
--- a/src/Revit/HyparRevit/Hypar.Revit.addin
+++ b/src/Revit/HyparRevit/Hypar.Revit.addin
@@ -4,7 +4,7 @@
     <Text>Hypar Hub Start</Text>
     <FullClassName>Hypar.Revit.HyparHubStartCommand</FullClassName>
     <Description>"Start the Hypar Hub sync."</Description>
-    <Assembly>C:/Users/Ian/Documents/GitHub/Hypar-1/Elements/src/Revit/HyparRevit/bin/Debug/netstandard2.0/publish/Hypar.Revit.dll</Assembly>
+    <Assembly>Hypar.Revit/Hypar.Revit.dll</Assembly>
     <AddInId>9a956586-8d1c-4cd1-a487-61990d3769fa</AddInId>
     <VendorDescription>"Hypar Inc., hypar.io"</VendorDescription>
     <VendorId>HYPR</VendorId>
@@ -13,7 +13,7 @@
     <Text>Hypar Hub Stop</Text>
     <FullClassName>Hypar.Revit.HyparHubStopCommand</FullClassName>
     <Description>"Stop the Hypar Hub sync."</Description>
-    <Assembly>C:/Users/Ian/Documents/GitHub/Hypar-1/Elements/src/Revit/HyparRevit/bin/Debug/netstandard2.0/publish/Hypar.Revit.dll</Assembly>
+    <Assembly>Hypar.Revit/Hypar.Revit.dll</Assembly>
     <AddInId>74a19e88-1577-41f6-b407-90600500b736</AddInId>
     <VendorDescription>"Hypar Inc., hypar.io"</VendorDescription>
     <VendorId>HYPR</VendorId>
@@ -22,7 +22,7 @@
     <Name>HyparRevit</Name>
     <FullClassName>Hypar.Revit.HyparHubApp</FullClassName>
     <Description>"Sync with a Hypar workflow."</Description>
-    <Assembly>C:/Users/Ian/Documents/GitHub/Hypar-1/Elements/src/Revit/HyparRevit/bin/Debug/netstandard2.0/publish/Hypar.Revit.dll</Assembly>
+    <Assembly>Hypar.Revit/Hypar.Revit.dll</Assembly>
     <AddInId>502fe383-2648-4e98-adf8-5e6047f9dc34</AddInId>
     <VendorDescription>"Hypar Inc., hypar.io"</VendorDescription>
     <VendorId>HYPR</VendorId>

--- a/src/Revit/HyparRevit/Hypar.Revit.csproj
+++ b/src/Revit/HyparRevit/Hypar.Revit.csproj
@@ -15,8 +15,15 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <AddinFiles Include="$(TargetDir)publish\**\*"/>
+  </ItemGroup>
+
   <Target Name="CopyAddin" AfterTargets="AfterBuild">
-    <Copy SourceFiles="Hypar.Revit.addin" DestinationFolder="C:\ProgramData\Autodesk\Revit\Addins\2020" />
+    <RemoveDir Directories="$(AppData)\Autodesk\Revit\Addins\2020\Hypar.Revit"/>
+    <Message Importance="High" Text="Completed CopyAddin target."/>
+    <Copy SourceFiles="Hypar.Revit.addin" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\2020" />
+    <Copy SourceFiles="@(AddinFiles)" DestinationFiles="@(AddinFiles->'$(AppData)\Autodesk\Revit\Addins\2020\Hypar.Revit\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
BACKGROUND:
- While testing HyparHub revit client I wanted to make the local testing easier.

DESCRIPTION:
- change addin to point to nearby relative path
- msbuild targets that copy the dll to the folder.

TESTING:
- pull, `dotnet publish` see copied files and see message in console.
  
FUTURE WORK:
- We might not necessarily want to push the dll to the addins folder forever, especially if we have a hub that is locally installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ikeough/elements/1)
<!-- Reviewable:end -->
